### PR TITLE
Linux平台下新增AudioVideo分类

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "build": {
     "appId": "nz.co.enkru.${name}",
     "linux": {
-      "category": "Audio",
+      "category": "Audio";"AudioVideo",
       "target": [
         "AppImage",
         "deb"


### PR DESCRIPTION
mate-desktop环境需要AudioVideo分类才能准确的划到“影音”菜单栏~